### PR TITLE
Fix average daily consumption calculation in analytics

### DIFF
--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -26,7 +26,11 @@ def get_analytics(
     
     # Calculate totals
     total_consumption_ml = sum(log.volume_ml for log in logs)
-    average_daily_consumption_ml = total_consumption_ml / period_days if period_days > 0 else 0
+    
+    # Calculate average based on actual data days, not selected period days
+    unique_dates = set(log.date for log in logs)
+    actual_data_days = len(unique_dates)
+    average_daily_consumption_ml = total_consumption_ml / actual_data_days if actual_data_days > 0 else 0
     
     # Calculate total cost
     total_cost = 0.0


### PR DESCRIPTION
Changed the calculation to use actual data days instead of selected period days. This provides accurate averages when data exists for fewer days than the selected period.

Before: average = total_consumption / period_days (e.g., 2660mL / 30d = 88.7mL)
After: average = total_consumption / actual_data_days (e.g., 2660mL / 2d = 1330mL)

🤖 Generated with [Claude Code](https://claude.ai/code)